### PR TITLE
speed up render function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "simple-html"
-version = "1.0.0"
+version = "1.0.1"
 readme = "README.md"
 description = "Template-less html rendering in Python"
 authors = ["Keith Philpott <fakekeith@example.org>"]


### PR DESCRIPTION
iterating within `_render` should allow for fewer function calls. According to benchmarks, it looks like this yields something in the range of a 2% to 5% performance improvement.