### PR TITLE
Allow numbers (int, float, Decimal) in `Node` and attributes

### DIFF
--- a/simple_html/utils.py
+++ b/simple_html/utils.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from types import GeneratorType
 from typing import Any, Union, Generator, Iterable, Callable, Final
 
@@ -30,6 +31,9 @@ def faster_escape(s: str) -> str:
 Node = Union[
     str,
     SafeString,
+    float,
+    int,
+    Decimal,
     list["Node"],
     Generator["Node", None, None],
     "Tag",
@@ -176,6 +180,8 @@ def _render(nodes: Iterable[Node], append_to_list: Callable[[str], None]) -> Non
             append_to_list(node.rendered)
         elif type(node) is list or type(node) is GeneratorType:
             _render(node, append_to_list)
+        elif isinstance(node, (int, float, Decimal)):
+            append_to_list(str(node))
         else:
             raise TypeError(f"Got unknown type: {type(node)}")
 
@@ -393,8 +399,9 @@ _common_safe_css_props: Final[frozenset[str]] = frozenset(
 )
 
 
+
 def render_styles(
-    styles: dict[Union[str, SafeString], Union[str, int, float, SafeString]]
+    styles: dict[Union[str, SafeString], Union[str, int, float, Decimal, SafeString]]
 ) -> SafeString:
     ret = ""
     for k, v in styles.items():
@@ -404,9 +411,9 @@ def render_styles(
             else:
                 k = faster_escape(k)
 
-        if type(v) is SafeString:
+        if isinstance(v, SafeString):
             v = v.safe_str
-        elif type(v) is str:
+        elif isinstance(v, str):
             v = faster_escape(v)
         # note that ints and floats pass through these condition checks
 

--- a/tests/test_simple_html.py
+++ b/tests/test_simple_html.py
@@ -1,4 +1,5 @@
 import json
+from decimal import Decimal
 from typing import Generator
 
 from simple_html import (
@@ -222,17 +223,20 @@ def test_safe_string_eq() -> None:
     assert SafeString("abc123") == SafeString("abc123")
 
 
+
 def test_render_styles() -> None:
     assert render_styles({}) == SafeString("")
     assert render_styles({"abc": 123.45}) == SafeString("abc:123.45;")
-    assert render_styles({"padding": 0, "margin": "0 10"}) == SafeString(
-        "padding:0;margin:0 10;"
+    assert render_styles({"padding": 0, "margin": "0 10", "line-height": Decimal('2.3')}) == SafeString(
+        "padding:0;margin:0 10;line-height:2.3;"
     )
 
     assert (
         render(div({"style": render_styles({"min-width": "25px"})}, "cool"))
         == '<div style="min-width:25px;">cool</div>'
     )
+
+
 
 
 def test_render_styles_escapes() -> None:
@@ -245,3 +249,15 @@ def test_attrs_not_required() -> None:
         render(div(p({"class": "ok"}, "neat", br, "ok"))) ==
         '<div><p class="ok">neat<br/>ok</p></div>'
     )
+
+def test_works_for_int() -> None:
+    assert render(5) == "5"
+    assert render(div({}, -500)) == "<div>-500</div>"
+
+def test_works_for_float() -> None:
+    assert render(5.0) == "5.0"
+    assert render(div({}, -123.456)) == "<div>-123.456</div>"
+
+def test_works_for_decimal() -> None:
+    assert render(Decimal("5.0")) == "5.0"
+    assert render(div({}, Decimal("-123.456"))) == "<div>-123.456</div>"


### PR DESCRIPTION
int, float, and Decimal all have good fidelity when rendered to strings, so we can just do the string conversion implicitly.